### PR TITLE
chore: add newInternal and newOutofRange

### DIFF
--- a/ferrors/error.go
+++ b/ferrors/error.go
@@ -520,14 +520,11 @@ func NewAlreadyExistsError(msg string, fields ...Field) Ferror {
 
 // NewInternalError returns an internal error.
 // It also records the stack trace at the point it was called.
-func NewInternalError(msg string, fields ...Field) Ferror {
-	return &withFields{
-		fundamental: &fundamental{
-			ErrorCode: Internal,
-			stack:     callers(),
-			Msg:       msg,
-		},
-		Fields: fields,
+func NewInternalError(msg string) Ferror {
+	return &fundamental{
+		ErrorCode: Internal,
+		stack:     callers(),
+		Msg:       msg,
 	}
 }
 

--- a/ferrors/error.go
+++ b/ferrors/error.go
@@ -518,6 +518,32 @@ func NewAlreadyExistsError(msg string, fields ...Field) Ferror {
 	}
 }
 
+// NewInternalError returns an internal error.
+// It also records the stack trace at the point it was called.
+func NewInternalError(msg string, fields ...Field) Ferror {
+	return &withFields{
+		fundamental: &fundamental{
+			ErrorCode: Internal,
+			stack:     callers(),
+			Msg:       msg,
+		},
+		Fields: fields,
+	}
+}
+
+// NewOutOfRangeError returns an out of range error.
+// It also records the stack trace at the point it was called.
+func NewOutOfRangeError(msg string, fields ...Field) Ferror {
+	return &withFields{
+		fundamental: &fundamental{
+			ErrorCode: OutOfRange,
+			stack:     callers(),
+			Msg:       msg,
+		},
+		Fields: fields,
+	}
+}
+
 // NewPermissionDeniedError returns permission denied error
 // It also records the stack trace at the point it was called.
 func NewPermissionDeniedError(msg string) Ferror {


### PR DESCRIPTION
Adds new abstraction of NewInternalError and NewOutOfRange error to replace those used in trading service. 