### PR TITLE
Fix/expand secret env

### DIFF
--- a/fconfig/config.go
+++ b/fconfig/config.go
@@ -57,6 +57,7 @@ func loadConfig(file string, config interface{}) error {
 		// expand environment variables inside config file
 		// e.g. ${ENV_NAME}
 		v.Set(key, os.ExpandEnv(val))
+		val = v.GetString(key)
 
 		// fetch the secret if value matches the secretRegex
 		if secretRegex.MatchString(val) {
@@ -87,10 +88,11 @@ func loadConfig(file string, config interface{}) error {
 // It maps the fields using `mapstructure` tag.
 //
 // Example:
-//   type Config struct {
-//   	 Env   string `mapstructure:env`
-//   	 DBUri string `mapstructure:db_uri`
-//   }
+//
+//	type Config struct {
+//		 Env   string `mapstructure:env`
+//		 DBUri string `mapstructure:db_uri`
+//	}
 //
 // It expands the environment variables if the value matches `${ENV_NAME}`.
 // It fetches the secret if the value matches gSecret://uri.

--- a/fconfig/config.go
+++ b/fconfig/config.go
@@ -56,31 +56,44 @@ func loadConfig(file string, config interface{}) error {
 		}
 		// expand environment variables inside config file
 		// e.g. ${ENV_NAME}
-		v.Set(key, os.ExpandEnv(val))
-		val = v.GetString(key)
+		expandEnvVars(v, key)
 
 		// fetch the secret if value matches the secretRegex
-		if secretRegex.MatchString(val) {
-			if sc == nil {
-				gsc, err := gcp.NewSecretClient()
-				if err != nil {
-					return err
-				}
-				// wrap gsc into secretClient to support `gSecret://` expansion.
-				sc = &secretClient{SecretClient: gsc}
-			}
-			secret, err := sc.getSecret(val)
-			if err != nil {
-				return err
-			}
-
-			v.Set(key, secret)
+		err = expandGSecrets(sc, v, key)
+		if err != nil {
+			return err
 		}
 	}
 	if sc != nil {
 		_ = sc.Close()
 	}
 	return v.Unmarshal(config)
+}
+
+func expandGSecrets(sc *secretClient, v *viper.Viper, key string) error {
+	val := v.GetString(key)
+	if secretRegex.MatchString(val) {
+		if sc == nil {
+			gsc, err := gcp.NewSecretClient()
+			if err != nil {
+				return err
+			}
+			// wrap gsc into secretClient to support `gSecret://` expansion.
+			sc = &secretClient{SecretClient: gsc}
+		}
+		secret, err := sc.getSecret(val)
+		if err != nil {
+			return err
+		}
+
+		v.Set(key, secret)
+	}
+	return nil
+}
+
+func expandEnvVars(v *viper.Viper, key string) {
+	val := v.GetString(key)
+	v.Set(key, os.ExpandEnv(val))
 }
 
 // LoadConfig loads the configuration from a given file and unmarshal it into

--- a/fconfig/config_test.go
+++ b/fconfig/config_test.go
@@ -9,10 +9,11 @@ import (
 )
 
 type config struct {
-	EnvTestVar    string `mapstructure:"envTestVar"`
-	YamlTestVar   string `mapstructure:"yamlTestVar"`
-	SecretTestVar string `mapstructure:"secretTestVar"`
-	Nested        nested `mapstructure:"nested"`
+	EnvTestVar       string `mapstructure:"envTestVar"`
+	YamlTestVar      string `mapstructure:"yamlTestVar"`
+	SecretTestVar    string `mapstructure:"secretTestVar"`
+	SecretEnvTestVar string `mapstructure:"secretEnvTestVar"`
+	Nested           nested `mapstructure:"nested"`
 }
 
 type nested struct {
@@ -35,9 +36,10 @@ func TestLoadConfig(t *testing.T) {
 			configName: "testdata/config.yaml",
 			envName:    "testdata/test.env",
 			want: &config{
-				EnvTestVar:    "EnvVarValue 1235543",
-				YamlTestVar:   "Yaml Test",
-				SecretTestVar: "test-value",
+				EnvTestVar:       "EnvVarValue 1235543",
+				YamlTestVar:      "Yaml Test",
+				SecretTestVar:    "test-value",
+				SecretEnvTestVar: "test-value",
 				Nested: nested{
 					Val1: "test",
 					Val2: 2,
@@ -49,9 +51,10 @@ func TestLoadConfig(t *testing.T) {
 			name:       "config without secrets",
 			configName: "testdata/configWoSecret.yaml",
 			want: &config{
-				EnvTestVar:    "",
-				YamlTestVar:   "Yaml Test",
-				SecretTestVar: "",
+				EnvTestVar:       "",
+				YamlTestVar:      "Yaml Test",
+				SecretTestVar:    "",
+				SecretEnvTestVar: "",
 				Nested: nested{
 					Val1: "test",
 					Val2: 2,

--- a/fconfig/testdata/config.yaml
+++ b/fconfig/testdata/config.yaml
@@ -1,6 +1,7 @@
 yamlTestVar: "Yaml Test"
 envTestVar: "${ENV_TEST_VAR}"
 secretTestVar: "gSecret://projects/development-flahmingo/secrets/test-secret/versions/latest"
+secretEnvTestVar: "${SECRET_ENV_TEST_VAR}"
 
 nested:
   val1: "test"

--- a/fconfig/testdata/test.env
+++ b/fconfig/testdata/test.env
@@ -1,1 +1,2 @@
 ENV_TEST_VAR="EnvVarValue 1235543"
+SECRET_ENV_TEST_VAR="gSecret://projects/development-flahmingo/secrets/test-secret/versions/latest"


### PR DESCRIPTION
Issue where if the env var was a `gsecret://` url, it wouldn't get the secret.

Fixed that issue and refactored