### PR TITLE
fix: escaping dollar sign in values

### DIFF
--- a/fconfig/config.go
+++ b/fconfig/config.go
@@ -93,7 +93,16 @@ func expandGSecrets(sc *secretClient, v *viper.Viper, key string) error {
 
 func expandEnvVars(v *viper.Viper, key string) {
 	val := v.GetString(key)
-	v.Set(key, os.ExpandEnv(val))
+
+	eval := os.Expand(val, func(str string) string {
+		if str == "$" {
+			return "$"
+		}
+
+		return os.Getenv(str)
+	})
+
+	v.Set(key, eval)
 }
 
 // LoadConfig loads the configuration from a given file and unmarshal it into

--- a/ferrors/error.go
+++ b/ferrors/error.go
@@ -2,9 +2,9 @@
 //
 // The traditional error handling idiom in Go is roughly akin to
 //
-//     if err != nil {
-//             return err
-//     }
+//	if err != nil {
+//	        return err
+//	}
 //
 // which when applied recursively up the call stack results in error reports
 // without context or debugging information. The ferrors package allows
@@ -293,7 +293,7 @@ func (w *withFields) GRPCStatus() *status.Status {
 
 	// We do not care about other error codes in withFields
 	//
-	// nolint:exhaustive
+	//nolint:exhaustive
 	switch w.ErrorCode {
 	case InvalidArgument:
 		br := &errdetails.BadRequest{}
@@ -484,9 +484,9 @@ func Wrapf(err error, format string, args ...interface{}) Ferror {
 // An error value has a cause if it implements the following
 // interface:
 //
-//     type causer interface {
-//            Cause() error
-//     }
+//	type causer interface {
+//	       Cause() error
+//	}
 //
 // If the error does not implement Cause, the original error will
 // be returned. If the error is nil, nil will be returned without further
@@ -614,22 +614,22 @@ func Code(err error) ErrorCode {
 // Example of an error when creating an account with email, when email already exists.
 // is not enabled:
 //
-//     { "reason": "EMAIL_ALREADY_EXISTS"
-//       "metadata": {
-//         "email": "email is already in use"
-//       }
-//     }
+//	{ "reason": "EMAIL_ALREADY_EXISTS"
+//	  "metadata": {
+//	    "email": "email is already in use"
+//	  }
+//	}
 //
 // This response indicates that the pubsub.googleapis.com API is not enabled.
 //
 // Example of an error that is returned when attempting to create a Spanner
 // instance in a region that is out of stock:
 //
-//     { "reason": "MARKET_CLOSED"
-//       "metadata": {
-//         "info": "Market is closed."
-//       }
-//     }
+//	{ "reason": "MARKET_CLOSED"
+//	  "metadata": {
+//	    "info": "Market is closed."
+//	  }
+//	}
 type ErrorDetail errdetails.ErrorInfo
 
 // Reset resets the ErrorDetail.

--- a/ferrors/stack.go
+++ b/ferrors/stack.go
@@ -51,16 +51,16 @@ func (f Frame) name() string {
 
 // Format formats the frame according to the fmt.Formatter interface.
 //
-//    %s    source file
-//    %d    source line
-//    %n    function name
-//    %v    equivalent to %s:%d
+//	%s    source file
+//	%d    source line
+//	%n    function name
+//	%v    equivalent to %s:%d
 //
 // Format accepts flags that alter the printing of some verbs, as follows:
 //
-//    %+s   function name and path of source file relative to the compile time
-//          GOPATH separated by \n\t (<funcname>\n\t<path>)
-//    %+v   equivalent to %+s:%d
+//	%+s   function name and path of source file relative to the compile time
+//	      GOPATH separated by \n\t (<funcname>\n\t<path>)
+//	%+v   equivalent to %+s:%d
 func (f Frame) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 's':
@@ -98,12 +98,12 @@ type StackTrace []Frame
 
 // Format formats the stack of Frames according to the fmt.Formatter interface.
 //
-//    %s	lists source files for each Frame in the stack
-//    %v	lists the source file and line number for each Frame in the stack
+//	%s	lists source files for each Frame in the stack
+//	%v	lists the source file and line number for each Frame in the stack
 //
 // Format accepts flags that alter the printing of some verbs, as follows:
 //
-//    %+v   Prints filename, function, and line number for each Frame in the stack.
+//	%+v   Prints filename, function, and line number for each Frame in the stack.
 func (st StackTrace) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':


### PR DESCRIPTION
# Description
`os.ExpandEnv` escapes `$` and there is no other way to escape it.

Example:
We want the value `$APP` but `os.ExpandEnv` would escape the value and return `APP`.

# Solution
We want a way to escape the `$` using `$$`